### PR TITLE
fix: bug dot-env in database/config.js module

### DIFF
--- a/src/database/config/config.js
+++ b/src/database/config/config.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const config = {
   username: process.env.HOST_USERNAME ?? "root",
   password: process.env.HOST_PASSWORD ?? "root",
@@ -12,3 +13,4 @@ module.exports = {
   "test": config,
   "production": config
 }
+


### PR DESCRIPTION
I added missed dot-env config file in order to get process env variables.